### PR TITLE
Increase max length of text field to 20

### DIFF
--- a/es/ReactTelephoneInput.js
+++ b/es/ReactTelephoneInput.js
@@ -557,6 +557,7 @@ var ReactTelephoneInput = function (_React$Component) {
     // for all strings with length less than 3, just return it (1, 2 etc.)
     // also return the same text if the selected country has no fixed format
     if (text && text.length < 2 || !pattern || !this.props.autoFormat) {
+      this.setState({ maxLength: undefined });
       return '+' + text;
     }
     var formatter = new asYouType();
@@ -818,7 +819,7 @@ var ReactTelephoneInput = function (_React$Component) {
           errorText: errorText,
           errorStyle: errorStyle,
           title: formattedNumber,
-          maxLength: maxLength || 17,
+          maxLength: maxLength || 20,
           floatingLabelText: floatingLabelText,
           floatingLabelStyle: floatingLabelStyle,
           inputStyle: inputStyle,

--- a/lib/ReactTelephoneInput.js
+++ b/lib/ReactTelephoneInput.js
@@ -631,6 +631,7 @@ var ReactTelephoneInput = function (_React$Component) {
     // for all strings with length less than 3, just return it (1, 2 etc.)
     // also return the same text if the selected country has no fixed format
     if (text && text.length < 2 || !pattern || !this.props.autoFormat) {
+      this.setState({ maxLength: undefined });
       return '+' + text;
     }
     var formatter = new _libphonenumberJs.asYouType();
@@ -892,7 +893,7 @@ var ReactTelephoneInput = function (_React$Component) {
           errorText: errorText,
           errorStyle: errorStyle,
           title: formattedNumber,
-          maxLength: maxLength || 17,
+          maxLength: maxLength || 20,
           floatingLabelText: floatingLabelText,
           floatingLabelStyle: floatingLabelStyle,
           inputStyle: inputStyle,

--- a/src/ReactTelephoneInput.js
+++ b/src/ReactTelephoneInput.js
@@ -349,6 +349,7 @@ class ReactTelephoneInput extends React.Component {
     // for all strings with length less than 3, just return it (1, 2 etc.)
     // also return the same text if the selected country has no fixed format
     if ((text && text.length < 2) || !pattern || !this.props.autoFormat) {
+      this.setState({ maxLength: undefined })
       return `+${text}`
     }
     const formatter = new asYouType()
@@ -928,7 +929,7 @@ class ReactTelephoneInput extends React.Component {
               errorText={errorText}
               errorStyle={errorStyle}
               title={formattedNumber}
-              maxLength={maxLength || 17}
+              maxLength={maxLength || 20}
               floatingLabelText={floatingLabelText}
               floatingLabelStyle={floatingLabelStyle}
               inputStyle={inputStyle}


### PR DESCRIPTION
Resetting max length state value when the country changes.
Increase max length to 20 to accommodate german numbers up to 15 digits with formatting.